### PR TITLE
Fix https drain message parse

### DIFF
--- a/lib/fluent/plugin/in_heroku_syslog_http.rb
+++ b/lib/fluent/plugin/in_heroku_syslog_http.rb
@@ -6,7 +6,7 @@ module Fluent
     Plugin.register_input('heroku_syslog_http', self)
     include Logplex
 
-    config_param :format, :string, :default => SYSLOG_REGEXP
+    config_param :format, :string, :default => SYSLOG_HTTP_REGEXP
     config_param :drain_ids, :array, :default => nil
 
     private

--- a/lib/fluent/plugin/logplex.rb
+++ b/lib/fluent/plugin/logplex.rb
@@ -1,6 +1,7 @@
 module Fluent
   module Logplex
     SYSLOG_REGEXP = '/^([0-9]+)\\s+\\<(?<pri>[0-9]+)\\>[0-9]* (?<time>[^ ]*) (?<drain_id>[^ ]*) (?<ident>[a-zA-Z0-9_\\/\\.\\-]*) (?<pid>[a-zA-Z0-9\\.]+)? *(?<message>.*)$/'
+    SYSLOG_HTTP_REGEXP = '/^([0-9]+)\\s+\\<(?<pri>[0-9]+)\\>[0-9]* (?<time>[^ ]*) (?<drain_id>[^ ]*) (?<ident>[a-zA-Z0-9_\\/\\.\\-]*) (?<pid>[a-zA-Z0-9\\.]+)? *- *(?<message>.*)$/'
 
     FACILITY_MAP = {
       0   => 'kern',

--- a/test/plugin/test_in_heroku_syslog_http.rb
+++ b/test/plugin/test_in_heroku_syslog_http.rb
@@ -31,12 +31,12 @@ class HerokuSyslogHttpInputTest < Test::Unit::TestCase
 
     tests = [
       {
-          'msg' => "<13>1 2014-01-29T06:25:52.589365+00:00 host app web.1 foo",
+          'msg' => "<13>1 2014-01-29T06:25:52.589365+00:00 host app web.1 - foo",
           'expected' => 'foo',
           'expected_time' => Time.strptime('2014-01-29T06:25:52+00:00', '%Y-%m-%dT%H:%M:%S%z').to_i
       },
       {
-          'msg' => "<13>1 2014-01-30T07:35:00.123456+09:00 host app web.1 bar",
+          'msg' => "<13>1 2014-01-30T07:35:00.123456+09:00 host app web.1 - bar",
           'expected' => 'bar',
           'expected_time' => Time.strptime('2014-01-30T07:35:00+09:00', '%Y-%m-%dT%H:%M:%S%z').to_i
       }
@@ -146,12 +146,12 @@ class HerokuSyslogHttpInputTest < Test::Unit::TestCase
     # actual syslog message has "\n"
     msgs = [
       {
-        'msg' => '<13>1 2014-01-01T01:23:45.123456+00:00 host app web.1 ' + 'x' * 100,
+        'msg' => '<13>1 2014-01-01T01:23:45.123456+00:00 host app web.1 - ' + 'x' * 100,
         'expected' => 'x' * 100,
         'expected_time' => Time.parse("2014-01-01T01:23:45 UTC").to_i
       },
       {
-        'msg' => '<13>1 2014-01-01T01:23:45.123456+00:00 host app web.1 ' + 'x' * 1024,
+        'msg' => '<13>1 2014-01-01T01:23:45.123456+00:00 host app web.1 - ' + 'x' * 1024,
         'expected' => 'x' * 1024,
         'expected_time' => Time.parse("2014-01-01T01:23:45 UTC").to_i
       }


### PR DESCRIPTION
HTTP(S) drains is not same format as SYSLOG drain.

https://devcenter.heroku.com/articles/log-drains#http-s-drains