### PR TITLE
Updated plugin to work with newer namespace for FluentD

### DIFF
--- a/lib/fluent/plugin/in_heroku_syslog_http.rb
+++ b/lib/fluent/plugin/in_heroku_syslog_http.rb
@@ -2,7 +2,7 @@ require 'fluent/plugin/in_http'
 require_relative 'logplex'
 
 module Fluent
-  class HerokuSyslogHttpInput < HttpInput
+  class HerokuSyslogHttpInput < Plugin::HttpInput
     Plugin.register_input('heroku_syslog_http', self)
     include Logplex
 


### PR DESCRIPTION
The newer versions of FluentD have the HttpInput class namespaced under `FluentD::Plugin::` so I added the updated class path to the `HerokuSyslogHttpInput` class.